### PR TITLE
Compressed Extension Support in Pcore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ uartbuild_root := sdk/example-uart/build/
 src := bench/pcore_tb.sv							\
 	   $(wildcard rtl/*.sv)							\
 	   $(wildcard rtl/core/*.sv)						\
+	   $(wildcard rtl/core/pipeline/*.v)					\
 	   $(wildcard rtl/core/*/*.sv)						\
 	   $(wildcard rtl/interconnect/*.sv)					\
 	   $(wildcard rtl/memory/*.sv)						\
@@ -36,10 +37,12 @@ verilate_command := $(verilator) +define+$(defines) 				\
 					-Wno-TIMESCALEMOD 			\
 					-Wno-MULTIDRIVEN 			\
 					-Wno-CASEOVERLAP 			\
-        				-Wno-WIDTH  			\
+        				-Wno-WIDTH  				\
 					-Wno-UNOPTFLAT 				\
 					-Wno-IMPLICIT 				\
 					-Wno-PINMISSING 			\
+					--prof-cfuncs 				\
+					-DVL_DEBUG -CFLAGS 			\
 					--Mdir $(ver-library)			\
 					--exe bench/pcore_tb.cpp		\
 					--trace-structs --trace
@@ -70,9 +73,6 @@ sim-verilate-linux: verilate
 	$(ver-library)/Vpcore_tb +imem=$(imem_linux) +max_cycles=300000000 +vcd=$(vcd)
 
 clean-all:
-	rm -rf ver_work/ *.log *.vcd 					\
-	$(uartbuild_root)*.o  $(uartbuild_root)*.bin 			\
-	$(uartbuild_root)*.hex $(uartbuild_root)*.elf 			\
-	$(uartbuild_root)*.dump						\
+	rm -rf ver_work/ *.log *.vcd \
 	verif/*work/
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [![pcore-riscof](https://github.com/ee-uet/UETRV-PCore/actions/workflows/main.yml/badge.svg)](https://github.com/ee-uet/UETRV-PCore/actions/workflows/main.yml)
 [![Documentation status](https://img.shields.io/badge/Docs-Passing-brightgreen)](https://uetrv-pcore-doc.readthedocs.io/en/main/index.html)
 
-UETRV_Pcore is a RISC-V based application class SoC integrating a 5-stage pipelined processor with memory and peripherals. Currently, the core implements RV32IMAZicsr ISA based on User-level ISA Version 2.0 and Privileged Architecture Version 1.11 supporting M/S/U modes. Following are the key features of the SoC:
+UETRV_Pcore is a RISC-V based application class SoC integrating a 5-stage pipelined processor with memory and peripherals. Currently, the core implements RV32IMACZicsr ISA based on User-level ISA Version 2.0 and Privileged Architecture Version 1.11 supporting M/S/U modes. Following are the key features of the SoC:
 
 ## Key Features
-- 32-bit RISC-V ISA core that supports base integer (I) and multiplication and division (M), atomic (A) and Zicsr (Z) extensions (RV32IMAZicsr).
+- 32-bit RISC-V ISA core that supports base integer (I) and multiplication and division (M), atomic (A), compressed (C) and Zicsr (Z) extensions (RV32IMACZicsr).
 - Supports user, supervisor and machine mode privilege levels.
 - Support for instruction / data (writeback) caches.
 - Sv32 based MMU support and is capable of running Linux.

--- a/rtl/core/pipeline/decompress.v
+++ b/rtl/core/pipeline/decompress.v
@@ -1,0 +1,235 @@
+// Copyright 2023 University of Engineering and Technology Lahore.
+// Licensed under the Apache License, Version 2.0, see LICENSE file for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: 16-bit to 32-bit decoder for Compressed Instructions
+//
+// Author: Abdul Wadood, UET Lahore
+// Date: 7.10.2023
+
+// ToDo: Make it consistent with Pcore sv code base.
+//       Functionally working at the moment.
+
+module decompress 
+  (
+   input wire i_clk,
+   input  wire [31:0] i_instr,
+   input  wire i_ack,
+   output wire [31:0] o_instr,
+   output wire o_iscomp);
+
+  localparam OPCODE_LOAD     = 7'h03;
+  localparam OPCODE_OP_IMM   = 7'h13;
+  localparam OPCODE_STORE    = 7'h23;
+  localparam OPCODE_OP       = 7'h33;
+  localparam OPCODE_LUI      = 7'h37;
+  localparam OPCODE_BRANCH   = 7'h63;
+  localparam OPCODE_JALR     = 7'h67;
+  localparam OPCODE_JAL      = 7'h6f;
+
+  reg  [31:0] comp_instr;
+  reg  illegal_instr;
+
+  assign o_instr = illegal_instr ? i_instr : comp_instr;
+
+//   always @(posedge *) begin
+//       o_iscomp = !illegal_instr; 
+//   end
+  assign o_iscomp = ~illegal_instr;
+
+  always @ (*) begin
+    // By default, forward incoming instruction, mark it as legal.
+    comp_instr    = i_instr;
+    illegal_instr = 1'b0;
+
+    // Check if incoming instruction is compressed.
+    case (i_instr[1:0])
+      // C0
+      2'b00: begin
+        case (i_instr[15:14])
+          2'b00: begin
+            // c.addi4spn -> addi rd', x2, imm
+            comp_instr = {2'b0, i_instr[10:7], i_instr[12:11], i_instr[5],
+                      i_instr[6], 2'b00, 5'h02, 3'b000, 2'b01, i_instr[4:2], {OPCODE_OP_IMM}};
+          end
+
+          2'b01: begin
+            // c.lw -> lw rd', imm(rs1')
+            comp_instr = {5'b0, i_instr[5], i_instr[12:10], i_instr[6],
+                      2'b00, 2'b01, i_instr[9:7], 3'b010, 2'b01, i_instr[4:2], {OPCODE_LOAD}};
+          end
+
+          2'b11: begin
+            // c.sw -> sw rs2', imm(rs1')
+            comp_instr = {5'b0, i_instr[5], i_instr[12], 2'b01, i_instr[4:2],
+                      2'b01, i_instr[9:7], 3'b010, i_instr[11:10], i_instr[6],
+                      2'b00, {OPCODE_STORE}};
+          end
+
+          2'b10: begin
+            illegal_instr = 1'b1;
+          end
+
+        endcase
+      end
+
+      // C1
+ 
+      // Register address checks for RV32E are performed in the regular instruction decoder.
+      // If this check fails, an illegal instruction exception is triggered and the controller
+      // writes the actual faulting instruction to mtval.
+      2'b01: begin
+        case (i_instr[15:13])
+          3'b000: begin
+            // c.addi -> addi rd, rd, nzimm
+            // c.nop
+            comp_instr = {{6 {i_instr[12]}}, i_instr[12], i_instr[6:2],
+                      i_instr[11:7], 3'b0, i_instr[11:7], {OPCODE_OP_IMM}};
+          end
+
+          3'b001, 3'b101: begin
+            // 001: c.jal -> jal x1, imm
+            // 101: c.j   -> jal x0, imm
+            comp_instr = {i_instr[12], i_instr[8], i_instr[10:9], i_instr[6],
+                      i_instr[7], i_instr[2], i_instr[11], i_instr[5:3],
+                      {9 {i_instr[12]}}, 4'b0, ~i_instr[15], {OPCODE_JAL}};
+          end
+
+          3'b010: begin
+            // c.li -> addi rd, x0, nzimm
+            // (c.li hints are translated into an addi hint)
+            comp_instr = {{6 {i_instr[12]}}, i_instr[12], i_instr[6:2], 5'b0,
+                      3'b0, i_instr[11:7], {OPCODE_OP_IMM}};
+          end
+
+          3'b011: begin
+            // c.lui -> lui rd, imm
+            // (c.lui hints are translated into a lui hint)
+            comp_instr = {{15 {i_instr[12]}}, i_instr[6:2], i_instr[11:7], {OPCODE_LUI}};
+
+            if (i_instr[11:7] == 5'h02) begin
+              // c.addi16sp -> addi x2, x2, nzimm
+              comp_instr = {{3 {i_instr[12]}}, i_instr[4:3], i_instr[5], i_instr[2],
+                        i_instr[6], 4'b0, 5'h02, 3'b000, 5'h02, {OPCODE_OP_IMM}};
+            end
+
+          end
+
+          3'b100: begin
+            case (i_instr[11:10])
+              2'b00,
+              2'b01: begin
+                // 00: c.srli -> srli rd, rd, shamt
+                // 01: c.srai -> srai rd, rd, shamt
+                // (c.srli/c.srai hints are translated into a srli/srai hint)
+                comp_instr = {1'b0, i_instr[10], 5'b0, i_instr[6:2], 2'b01, i_instr[9:7],
+                          3'b101, 2'b01, i_instr[9:7], {OPCODE_OP_IMM}};
+              end
+
+              2'b10: begin
+                // c.andi -> andi rd, rd, imm
+                comp_instr = {{6 {i_instr[12]}}, i_instr[12], i_instr[6:2], 2'b01, i_instr[9:7],
+                          3'b111, 2'b01, i_instr[9:7], {OPCODE_OP_IMM}};
+              end
+
+              2'b11: begin
+                case (i_instr[6:5])
+                  2'b00: begin
+                    // c.sub -> sub rd', rd', rs2'
+                    comp_instr = {2'b01, 5'b0, 2'b01, i_instr[4:2], 2'b01, i_instr[9:7],
+                                  3'b000, 2'b01, i_instr[9:7], {OPCODE_OP}};
+                  end
+
+                  2'b01: begin
+                    // c.xor -> xor rd', rd', rs2'
+                    comp_instr = {7'b0, 2'b01, i_instr[4:2], 2'b01, i_instr[9:7], 3'b100,
+                              2'b01, i_instr[9:7], {OPCODE_OP}};
+                  end
+
+                  2'b10: begin
+                    // c.or  -> or  rd', rd', rs2'
+                    comp_instr = {7'b0, 2'b01, i_instr[4:2], 2'b01, i_instr[9:7], 3'b110,
+                              2'b01, i_instr[9:7], {OPCODE_OP}};
+                  end
+
+                  2'b11: begin
+                    // c.and -> and rd', rd', rs2'
+                    comp_instr = {7'b0, 2'b01, i_instr[4:2], 2'b01, i_instr[9:7], 3'b111,
+                              2'b01, i_instr[9:7], {OPCODE_OP}};
+                  end
+                endcase
+              end
+            endcase
+          end
+
+          3'b110, 3'b111: begin
+            // 0: c.beqz -> beq rs1', x0, imm
+            // 1: c.bnez -> bne rs1', x0, imm
+            comp_instr = {{4 {i_instr[12]}}, i_instr[6:5], i_instr[2], 5'b0, 2'b01,
+                      i_instr[9:7], 2'b00, i_instr[13], i_instr[11:10], i_instr[4:3],
+                      i_instr[12], {OPCODE_BRANCH}};
+          end
+        endcase
+      end
+
+      // C2
+
+      // Register address checks for RV32E are performed in the regular instruction decoder.
+      // If this check fails, an illegal instruction exception is triggered and the controller
+      // writes the actual faulting instruction to mtval.
+      2'b10: begin
+        case (i_instr[15:14])
+          2'b00: begin
+            // c.slli -> slli rd, rd, shamt
+            // (c.ssli hints are translated into a slli hint)
+            comp_instr = {7'b0, i_instr[6:2], i_instr[11:7], 3'b001, i_instr[11:7], {OPCODE_OP_IMM}};
+          end
+
+          2'b01: begin
+            // c.lwsp -> lw rd, imm(x2)
+            comp_instr = {4'b0, i_instr[3:2], i_instr[12], i_instr[6:4], 2'b00, 5'h02,
+                      3'b010, i_instr[11:7], OPCODE_LOAD};
+          end
+
+          2'b10: begin
+            if (i_instr[12] == 1'b0) begin
+              if (i_instr[6:2] != 5'b0) begin
+                // c.mv -> add rd/rs1, x0, rs2
+                // (c.mv hints are translated into an add hint)
+                comp_instr = {7'b0, i_instr[6:2], 5'b0, 3'b0, i_instr[11:7], {OPCODE_OP}};
+              end else begin
+                // c.jr -> jalr x0, rd/rs1, 0
+                comp_instr = {12'b0, i_instr[11:7], 3'b0, 5'b0, {OPCODE_JALR}};
+              end
+            end else begin
+              if (i_instr[6:2] != 5'b0) begin
+                // c.add -> add rd, rd, rs2
+                // (c.add hints are translated into an add hint)
+                comp_instr = {7'b0, i_instr[6:2], i_instr[11:7], 3'b0, i_instr[11:7], {OPCODE_OP}};
+              end else begin
+                if (i_instr[11:7] == 5'b0) begin
+                  // c.ebreak -> ebreak
+                  comp_instr = {32'h00_10_00_73};
+                end else begin
+                  // c.jalr -> jalr x1, rs1, 0
+                  comp_instr = {12'b0, i_instr[11:7], 3'b000, 5'b00001, {OPCODE_JALR}};
+                end
+              end
+            end
+          end
+
+          2'b11: begin
+            // c.swsp -> sw rs2, imm(x2)
+            comp_instr = {4'b0, i_instr[8:7], i_instr[12], i_instr[6:2], 5'h02, 3'b010,
+                      i_instr[11:9], 2'b00, {OPCODE_STORE}};
+          end
+        endcase
+      end
+
+      // Incoming instruction is not compressed.
+      2'b11: illegal_instr = 1'b1;
+
+    endcase
+  end
+  
+  endmodule

--- a/rtl/core/pipeline/execute.sv
+++ b/rtl/core/pipeline/execute.sv
@@ -346,7 +346,7 @@ assign exe2fwd_o       = exe2fwd;
 assign exe2mul_o       = exe2mul;
 
 // Update the feedback signals from EXE to IF stage                         
-assign exe2if_fb.pc_new       = {alu_result[31:2], 2'b0};  // fence_i_req ? id2exe_data.pc_next :  
+assign exe2if_fb.pc_new       = {alu_result[31:1], 1'b0};
 // assign exe2if_fb.icache_flush = fence_i_req;                         
 assign exe2if_fb_o            = exe2if_fb;                  
 

--- a/rtl/core/pipeline/execute.sv
+++ b/rtl/core/pipeline/execute.sv
@@ -346,7 +346,11 @@ assign exe2fwd_o       = exe2fwd;
 assign exe2mul_o       = exe2mul;
 
 // Update the feedback signals from EXE to IF stage                         
+`ifdef COMPRESSED
 assign exe2if_fb.pc_new       = {alu_result[31:1], 1'b0};
+`else
+assign exe2if_fb.pc_new       = {alu_result[31:2], 2'b0};  // fence_i_req ? id2exe_data.pc_next :  
+`endif
 // assign exe2if_fb.icache_flush = fence_i_req;                         
 assign exe2if_fb_o            = exe2if_fb;                  
 

--- a/rtl/core/pipeline/fetch.sv
+++ b/rtl/core/pipeline/fetch.sv
@@ -79,7 +79,7 @@ assign csr2if_fb = csr2if_fb_i;
 assign fwd2if    = fwd2if_i;
 
 // Evaluation for misaligned address
-assign pc_misaligned = pc_ff[1] | pc_ff[0];
+assign pc_misaligned = pc_ff[0];
 
 // Stall signal for IF stage
 assign if_stall = fwd2if.if_stall | (~icache2if.ack) | irq_req_next;
@@ -94,7 +94,7 @@ always_ff @(posedge clk) begin
 end
 
 always_comb begin
-    pc_next = (pc_ff + 32'd4);
+    pc_next = (pc_ff + (icache2if.comp_ack ? 32'd2 : 32'd4));
 
     case (1'b1)
         fwd2if.csr_new_pc_req : begin
@@ -178,6 +178,8 @@ assign if2icache_o.req  = mmu2if.i_hit;              // `IMEM_INST_REQ;
 
 assign if2icache_o.req_kill     = kill_req;
 assign if2icache_o.icache_flush = csr2if_fb.icache_flush;   
+
+assign if2icache_o.if_stall     = fwd2if.if_stall;
 
 // Update the outputs to ID stage
 assign if2id_data.instr         = ((~icache2if.ack) | irq_req_next) ? `INSTR_NOP : icache2if.r_data;

--- a/rtl/core/pipeline/fetch.sv
+++ b/rtl/core/pipeline/fetch.sv
@@ -79,7 +79,11 @@ assign csr2if_fb = csr2if_fb_i;
 assign fwd2if    = fwd2if_i;
 
 // Evaluation for misaligned address
+`ifdef COMPRESSED
 assign pc_misaligned = pc_ff[0];
+`else
+assign pc_misaligned = pc_ff[1] | pc_ff[0];
+`endif 
 
 // Stall signal for IF stage
 assign if_stall = fwd2if.if_stall | (~icache2if.ack) | irq_req_next;

--- a/rtl/core/pipeline/pipeline_top.sv
+++ b/rtl/core/pipeline/pipeline_top.sv
@@ -94,6 +94,10 @@ type_dbus2lsu_s                         dbus2lsu;
 type_if2icache_s                        if2icache;              
 type_icache2if_s                        icache2if;
 
+// Interfaces for Icache <---> Pre-fetch <---> Instruction Fetch
+type_if2icache_s                        pf2icache, if2pf;
+type_icache2if_s                        icache2pf, pf2if;
+
 // Interfaces for writeback module
 type_lsu2wrb_ctrl_s                     lsu2wrb_ctrl;
 type_lsu2wrb_data_s                     lsu2wrb_data;
@@ -143,6 +147,22 @@ assign mmu2if    = mmu2if_i;
 assign mmu2lsu   = mmu2lsu_i;
 assign icache2if = icache2if_i;
 
+//================================= Prefetch to Fetch interface ================================//
+
+// pass through Icache IOs
+assign if2icache = pf2icache;
+assign icache2pf = icache2if;
+
+prefetch prefetch_module (
+    .rst_n                      (rst_n),
+    .clk                        (clk),
+    // ICache <---> Pre-fetch interface
+    .pf2icache_o                (pf2icache),
+    .icache2pf_i                (icache2pf),
+    // Pre-fetch <---> IF interface
+    .pf2if_o                    (pf2if),
+    .if2pf_i                    (if2pf)
+);
 
 //================================= Fetch to decode interface ==================================//
 
@@ -152,8 +172,8 @@ fetch fetch_module (
     .clk                        (clk),
 
     // IF module interface signals 
-    .if2icache_o                (if2icache),
-    .icache2if_i                (icache2if),
+    .if2icache_o                (if2pf),
+    .icache2if_i                (pf2if),
 
     .if2mmu_o                   (if2mmu),
     .mmu2if_i                   (mmu2if),

--- a/rtl/core/pipeline/prefetch.sv
+++ b/rtl/core/pipeline/prefetch.sv
@@ -1,0 +1,64 @@
+// Copyright 2023 University of Engineering and Technology Lahore.
+// Licensed under the Apache License, Version 2.0, see LICENSE file for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: Instruction Prefetch module act as top module to handle
+//              RISC-V Compressed Instructions.
+//
+//
+// Author: Abdul Wadood, UET Lahore
+// Date: 21.10.2023
+
+`ifndef VERILATOR
+`include "../../defines/cache_defs.svh"
+`else
+`include "cache_defs.svh"
+`endif
+
+module prefetch (
+    input   logic                                   rst_n,
+    input   logic                                   clk,
+    // IMEM <---> REALIGN interface
+    output type_if2icache_s                         pf2icache_o,
+    input wire type_icache2if_s                     icache2pf_i,
+
+    // REALIGN <---> IF interface
+    output type_icache2if_s                         pf2if_o,
+    input wire type_if2icache_s                     if2pf_i
+);
+
+// Interface for Realign
+type_icache2if_s pf2ralgn, ralgn2dcmp, dcmp2if;;
+type_if2icache_s ralgn2pf, if2ralgn;
+
+assign pf2ralgn     = icache2pf_i;
+assign if2ralgn     = if2pf_i;
+
+realign realign_module (
+    .rst_n                      (rst_n),
+    .clk                        (clk),
+    // REALIGN <------> ICache
+    .ralgn2icache_o             (ralgn2pf),
+    .icache2ralgn_i             (pf2ralgn),
+    // IF <-----> REALIGN
+    .ralgn2if_o                 (ralgn2dcmp),
+    .if2ralgn_i                 (if2ralgn)
+);
+
+// Todo: Make the following code consistent with the PCore sv code base. 
+//       Functionally working as of now.
+wire isComp;
+assign dcmp2if = ralgn2dcmp;
+assign dcmp2if.comp_ack   = isComp & ~if2ralgn.req_kill;
+decompress decompress_module (
+    .i_clk       (clk),
+    .i_instr     (ralgn2dcmp.r_data),
+    .i_ack       (ralgn2dcmp.ack),
+    .o_instr     (dcmp2if.r_data),
+    .o_iscomp    (isComp)
+);
+
+assign pf2if_o      = dcmp2if;
+assign pf2icache_o  = ralgn2pf;
+
+endmodule : prefetch

--- a/rtl/core/pipeline/prefetch.sv
+++ b/rtl/core/pipeline/prefetch.sv
@@ -27,7 +27,9 @@ module prefetch (
     input wire type_if2icache_s                     if2pf_i
 );
 
-// Interface for Realign
+`ifdef COMPRESSED
+
+// Interface for Realigner
 type_icache2if_s pf2ralgn, ralgn2dcmp, dcmp2if;;
 type_if2icache_s ralgn2pf, if2ralgn;
 
@@ -60,5 +62,13 @@ decompress decompress_module (
 
 assign pf2if_o      = dcmp2if;
 assign pf2icache_o  = ralgn2pf;
+
+`else 
+
+assign pf2if_o.comp_ack = 1'b0;
+assign pf2if_o          = icache2pf_i;
+assign pf2icache_o      = if2pf_i;
+
+`endif
 
 endmodule : prefetch

--- a/rtl/core/pipeline/realign.sv
+++ b/rtl/core/pipeline/realign.sv
@@ -1,0 +1,109 @@
+// Copyright 2023 University of Engineering and Technology Lahore.
+// Licensed under the Apache License, Version 2.0, see LICENSE file for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: Instruction Realigner for Compressed Extension
+//
+// Author: Abdul Wadood, UET Lahore
+// Date: 24.9.2023
+
+`ifndef VERILATOR
+`include "../../defines/cache_defs.svh"
+`else
+`include "cache_defs.svh"
+`endif
+
+module realign (
+    input   logic                                   rst_n,
+    input   logic                                   clk,
+    // IMEM <---> REALIGN interface
+    output type_if2icache_s                         ralgn2icache_o,
+    input wire type_icache2if_s                     icache2ralgn_i,
+
+    // REALIGN <---> IF interface
+    output type_icache2if_s                         ralgn2if_o,
+    input wire type_if2icache_s                     if2ralgn_i
+);
+
+// local signals for internal use
+type_if2icache_s                            ralgn2icache, if2ralgn;
+type_icache2if_s                            ralgn2if, icache2ralgn;
+
+// Signals for re-aligner state machine
+logic [`XLEN/2-1:0]                         lowerhw_buf;
+logic [`XLEN-1:0]                           realigned_instr;
+logic                                       conct_en, ack_en, pcP4_en;
+
+// Input signal assigments
+assign if2ralgn             = if2ralgn_i;
+assign icache2ralgn         = icache2ralgn_i;
+
+// Icache <---> Realign, pass through by default
+assign ralgn2icache         = if2ralgn; 
+assign ralgn2icache.addr    = (pcP4_en & ~if2ralgn.req_kill) ? (if2ralgn.addr + 32'b100) : if2ralgn.addr;
+
+assign ralgn2if.ack         = ack_en & icache2ralgn.ack;
+assign ralgn2if.r_data      = conct_en ? realigned_instr : icache2ralgn.r_data;
+
+// concatenated instruction
+assign realigned_instr = {icache2ralgn.r_data[15:0], lowerhw_buf};
+
+// saving lower half work of every valid instruction
+always_ff @(posedge clk) begin
+    if(icache2ralgn.ack & ~if2ralgn.if_stall) begin
+        lowerhw_buf <= icache2ralgn.r_data[31:16];
+    end
+end
+
+logic [1:0] cs, ns;
+localparam idle = 2'b00;
+localparam fetch_mis = 2'b01;
+localparam fetch_mis_ack = 2'b10;
+
+always_ff @(posedge clk) begin
+    if (~rst_n) begin
+        cs <= idle;
+    end else begin
+        cs <= ns;
+    end
+end
+// next state logic
+always_comb begin
+    case (cs)
+        idle: begin
+            ack_en          = 1;
+            conct_en        = 0;
+            pcP4_en         = 0;
+            ns              = if2ralgn.addr[1] ? fetch_mis : idle;
+        end
+        fetch_mis: begin
+            ack_en          = 0;
+            conct_en        = 1;
+            if(if2ralgn.req_kill)
+                ns          = if2ralgn.addr[1] ? fetch_mis : idle;
+            else begin
+                ns          = icache2ralgn.ack ? fetch_mis_ack : fetch_mis;
+                pcP4_en     = icache2ralgn.ack ? 1 : 0;
+            end
+        end
+        fetch_mis_ack: begin
+            ack_en          = 1;
+            conct_en        = 1;
+            if(if2ralgn.req_kill)
+                ns          = if2ralgn.addr[1] ? fetch_mis : idle;
+            else if(icache2ralgn.ack) begin
+                pcP4_en     = if2ralgn.addr[1] ? 1 : 0;
+                ns          = if2ralgn.addr[1] ? fetch_mis_ack : idle;
+            end
+        end
+        default: begin
+            
+        end
+    endcase
+end
+
+// Output signal assigments
+assign ralgn2icache_o   = ralgn2icache;
+assign ralgn2if_o       = ralgn2if;
+
+endmodule : realign

--- a/rtl/defines/cache_defs.svh
+++ b/rtl/defines/cache_defs.svh
@@ -38,12 +38,14 @@ typedef struct packed {
     logic                            req;
     logic                            req_kill;
     logic                            icache_flush; 
+    logic                            if_stall;
 } type_if2icache_s;
 
 // Bus interface from Icache to IF
 typedef struct packed {                            
     logic [ICACHE_DATA_WIDTH-1:0]    r_data;
     logic                            ack;  
+    logic                            comp_ack;
 } type_icache2if_s;
 
 

--- a/rtl/defines/pcore_config_defs.svh
+++ b/rtl/defines/pcore_config_defs.svh
@@ -19,6 +19,7 @@
 `define ICACHE_SETS                  2048
 `define DCACHE_SETS                  512
 
+`define COMPRESSED                   1
 //============================= CORE PARAMETERS ========================//
 
 // Width of main registers and buses

--- a/rtl/defines/pcore_interface_defs.svh
+++ b/rtl/defines/pcore_interface_defs.svh
@@ -17,6 +17,12 @@
 
 //============================== ISA related definitions ================================//
 
+typedef enum logic [1:0] {
+    RALGN_IDLE, 
+    RALGN_ICACHE_REQ,
+    RALGN_IF_ACK
+} type_ralgn_states_e;
+
 typedef enum logic [4:0] {
     OPCODE_LOAD_INST      = 5'b00000,
     OPCODE_STORE_INST     = 5'b01000,

--- a/verif/pcore-plugin/pcore_isa.yaml
+++ b/verif/pcore-plugin/pcore_isa.yaml
@@ -1,11 +1,11 @@
 hart_ids: [0]
 hart0:
-  ISA: RV32IMA
+  ISA: RV32IMAC
   physical_addr_sz: 32
   User_Spec_Version: '2.3'
   supported_xlen: [32]
   misa:
-   reset-val: 0x40001101
+   reset-val: 0x40001105
    rv32:
      accessible: true
      mxl:
@@ -23,6 +23,6 @@ hart0:
            warl:
               dependency_fields: []
               legal:
-                - extensions[25:0] bitmask [0x0001101, 0x0000000]
+                - extensions[25:0] bitmask [0x0001105, 0x0000000]
               wr_illegal:
                 - Unchanged

--- a/verif/pcore-plugin/riscof_pcore.py
+++ b/verif/pcore-plugin/riscof_pcore.py
@@ -57,7 +57,7 @@ class pcore(pluginTemplate):
        self.toplevel = 'pcore_tb'
        self.buidldir = 'sim_work'
        comp_pcore = 'verilator --Mdir {0} +define+COMPLIANCE=1 -cc \
-        $(find ../rtl/ -type f -name "*.sv")\
+        $(find ../rtl/ -type f -name "*v")\
         ../bench/{1}.sv  \
         -Wno-TIMESCALEMOD -Wno-MULTIDRIVEN -Wno-CASEOVERLAP \
         -Wno-WIDTH -Wno-UNOPTFLAT -Wno-IMPLICIT -Wno-PINMISSING \
@@ -69,7 +69,7 @@ class pcore(pluginTemplate):
 
        # Simulate
        self.sim_pcore = './{0}/V{1} \
-        +max_cycles=100000000 \
+        +max_cycles=1000000 \
         +imem={2}/{3}.hex'
 
     def build(self, isa_yaml, platform_yaml):


### PR DESCRIPTION
Changes:

- Add Pre-fetch (stage) in the pipeline between that run realigner state machine and decompress the compressed Instructions,
- Subtle changes in fetch and execute module to enable half-word misaligned Icache request, and does not raise exception on doing so.
- C extension support is parameterized with `define COMPRESSED` parameter.
- Include C extension tests in the RISCOF framework for PCORE. All tests are passing without breaking any existing test.