### PR TITLE
Privilege ACTs for Pcore

### DIFF
--- a/rtl/core/pipeline/csr.sv
+++ b/rtl/core/pipeline/csr.sv
@@ -935,10 +935,10 @@ always_comb begin
         m_mode_lsu_pf_exc_req   : begin
             csr_mtval_next = lsu2csr_data.dbus_addr;
         end
-        m_mode_i_pf_exc_req : begin
+        (m_mode_i_pf_exc_req | m_mode_break_exc_req): begin
             csr_mtval_next = csr_pc_next;
         end
-        (ms_mode_ecall_req | m_mode_break_exc_req | m_mode_irq_req) : begin
+        (ms_mode_ecall_req | m_mode_irq_req) : begin
             csr_mtval_next = '0;
         end
         csr_mtval_wr_flag      : begin  

--- a/verif/pcore-plugin/pcore_isa.yaml
+++ b/verif/pcore-plugin/pcore_isa.yaml
@@ -1,6 +1,6 @@
 hart_ids: [0]
 hart0:
-  ISA: RV32IMAC
+  ISA: RV32IMACZicsr
   physical_addr_sz: 32
   User_Spec_Version: '2.3'
   supported_xlen: [32]


### PR DESCRIPTION
Change: update mtval with instruction address on `ebreak`.

Rationale:
riscv-arch-tests assumes that `mtval` should be set with the instruction address
on ebreak, however, RISC-V privilege spec provides a choice whether to set 0 or
faulty address in mtval.
This change is to make pcore consistent with ACTs.
